### PR TITLE
Cover all API endpoint URLs and extend permission list

### DIFF
--- a/BESST/README.md
+++ b/BESST/README.md
@@ -15,7 +15,8 @@ It requires python3 and the following python (pip) packages: `socketserver`.
 To run the script, edit your system hostfile (`C:\windows\system32\drivers\etc\hosts` for example) and point the
 following domains to `127.0.0.1`: 
 
-- `api.besst.bafang-service.com` 
+- `api.besst.bafang-service.com`
+- `test.api.besst.bafang-service.com`
 - `eu-central-1.api.besst.bafang-service.com`
 - `bafang-besst.oss-cn-shanghai.aliyuncs.com`
 
@@ -26,6 +27,7 @@ On Windows that would look like:
 #	127.0.0.1       localhost
 #	::1             localhost
 127.0.0.1 api.besst.bafang-service.com
+127.0.0.1 test.api.besst.bafang-service.com
 127.0.0.1 eu-central-1.api.besst.bafang-service.com
 127.0.0.1 bafang-besst.oss-cn-shanghai.aliyuncs.com
 ```

--- a/BESST/loginbypass.py
+++ b/BESST/loginbypass.py
@@ -148,6 +148,7 @@ class BESST_server(BaseHTTPRequestHandler):
                             "file.error.add",
                             "file.error.edit",
                             "auth_material",
+                            "firmware.menu",
                         ]
                     },
                 }


### PR DESCRIPTION
- The version 1.2.43 of the application now includes the `firmware.menu` capability.
- Some of the API calls are hardcoded to `test.api.besst.bafang-service.com' so we add this to the host override list.